### PR TITLE
[REFACTOR] API 키 노출 제거 및 API Route 기반 리다이렉트 처리

### DIFF
--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const clientId = process.env.GOOGLE_ID!;
+  const redirectUri = process.env.GOOGLE_REDIRECT_URI!;
+  const scope = process.env.GOOGLE_SCOPE!;
+  const url = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code&scope=${scope}`;
+  return NextResponse.redirect(url);
+}

--- a/src/app/api/auth/kakao/route.ts
+++ b/src/app/api/auth/kakao/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const clientId = process.env.KAKAO_REST_API_KEY!;
+  const redirectUri = process.env.KAKAO_REDIRECT_URI!;
+  const url = `https://kauth.kakao.com/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code`;
+  return NextResponse.redirect(url);
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -25,27 +25,17 @@ export default function LoginPage() {
 
       const response = await axios.post(
         `${process.env.NEXT_PUBLIC_API_HOST}/api/auth/login`,
-        {
-          email,
-          password,
-        }
+        { email, password }
       );
 
       const { accessToken, refreshToken } = response.data.data;
       localStorage.setItem("accessToken", accessToken);
       localStorage.setItem("refreshToken", refreshToken);
-      Cookies.set("accessToken", accessToken, {
-        path: "/",
-        expires: 1 / 48,
-      });
-      Cookies.set("refreshToken", refreshToken, {
-        expires: 1 / 48,
-      });
-      console.log("로그인 성공:", response.data);
+      Cookies.set("accessToken", accessToken, { path: "/", expires: 1 / 48 });
+      Cookies.set("refreshToken", refreshToken, { expires: 1 / 48 });
 
       router.push("/art");
     } catch (err) {
-      console.error("로그인 실패:", err);
       alert("이메일 또는 비밀번호가 올바르지 않습니다.");
     } finally {
       setLoading(false);
@@ -53,18 +43,11 @@ export default function LoginPage() {
   };
 
   const handleGoogleLogin = () => {
-    const CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_ID!;
-    const REDIRECT_URI = process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI!;
-    const SCOPE = process.env.NEXT_PUBLIC_GOOGLE_SCOPE!;
-    const GOOGLE_AUTH_URL = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code&scope=${SCOPE}`;
-    window.location.href = GOOGLE_AUTH_URL;
+    window.location.href = "/api/auth/google";
   };
 
   const handleKakaoLogin = () => {
-    const KAKAO_CLIENT_ID = process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY!;
-    const REDIRECT_URI = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI!;
-    const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code`;
-    window.location.href = KAKAO_AUTH_URL;
+    window.location.href = "/api/auth/kakao";
   };
 
   return (


### PR DESCRIPTION
## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #23

## 📎 𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- API Route(`/api/auth/google`, `/api/auth/kakao`)에서 URL 생성 및 리다이렉트 처리하도록 리팩터링했습니다.
- .env.local 파일에서 NEXT_PUBLIC을 제외했습니다.

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
- 서치해서 수정했는데, 성은님이 말씀하신 방식이 맞게 적용됐는지 확인 부탁드립니다!
