### PR TITLE
[FEAT] 토큰 재발급 구현

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,9 +3,8 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
-import axios from "axios";
+import api from "@/libs/axiosInstance";
 import PrimaryButton from "@/components/Button/PrimaryButton";
-import Cookies from "js-cookie";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -23,16 +22,12 @@ export default function LoginPage() {
     try {
       setLoading(true);
 
-      const response = await axios.post(
-        `${process.env.NEXT_PUBLIC_API_HOST}/api/auth/login`,
-        { email, password }
-      );
+      const res = await api.post("/api/auth/login", { email, password });
+      const { accessToken } = res.data.data;
 
-      const { accessToken, refreshToken } = response.data.data;
-      localStorage.setItem("accessToken", accessToken);
-      localStorage.setItem("refreshToken", refreshToken);
-      Cookies.set("accessToken", accessToken, { path: "/", expires: 1 / 48 });
-      Cookies.set("refreshToken", refreshToken, { expires: 1 / 48 });
+      if (accessToken) {
+        localStorage.setItem("accessToken", accessToken);
+      }
 
       router.push("/art");
     } catch (err) {
@@ -63,21 +58,23 @@ export default function LoginPage() {
         onSubmit={handleSubmit}
         className="flex flex-col items-center gap-4 w-full max-w-xs"
       >
+        {/* 이메일 입력 */}
         <input
           type="email"
           placeholder="이메일을 입력해주세요"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className="w-full h-[58px] px-[16px] rounded-[8px] border border-[#9E9FAD] bg-white text-black text-[18px] font-medium font-[Pretendard] placeholder-gray4 focus:outline-none"
+          className="w-full h-[58px] px-[16px] rounded-[8px] border border-[#9E9FAD] bg-white text-black text-[18px] font-medium font-[Pretendard] placeholder-[#9E9FAD] focus:outline-none"
         />
 
+        {/* 비밀번호 입력 */}
         <div className="relative w-full mt-[16px]">
           <input
             type={showPassword ? "text" : "password"}
             placeholder="비밀번호를 입력해주세요"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="w-full h-[58px] px-[16px] pr-10 rounded-[8px] border border-[#9E9FAD] bg-white text-black text-[18px] font-medium font-[Pretendard] placeholder-gray4 focus:outline-none"
+            className="w-full h-[58px] px-[16px] pr-10 rounded-[8px] border border-[#9E9FAD] bg-white text-black text-[18px] font-medium font-[Pretendard] placeholder-[#9E9FAD] focus:outline-none"
           />
           <button
             type="button"
@@ -86,13 +83,14 @@ export default function LoginPage() {
           >
             <Image
               src={showPassword ? "/icon_close_eye.svg" : "/icon_eye.svg"}
-              alt="toggle password"
+              alt="비밀번호 표시 전환"
               width={20}
               height={20}
             />
           </button>
         </div>
 
+        {/* 로그인 버튼 */}
         <div className="mt-[24px] w-full">
           <PrimaryButton
             text={loading ? "로그인 중..." : "로그인"}
@@ -104,6 +102,7 @@ export default function LoginPage() {
         </div>
       </form>
 
+      {/* 비밀번호 찾기 / 회원가입 */}
       <div className="mt-[40px] mb-[48px] flex justify-center items-center gap-[8px] text-sm text-black font-sans">
         <button onClick={() => router.push("/signup/password/code")}>
           비밀번호 찾기
@@ -114,6 +113,7 @@ export default function LoginPage() {
         <button onClick={() => router.push("/signup")}>회원가입</button>
       </div>
 
+      {/* 간편 로그인 */}
       <div className="w-full max-w-xs flex flex-col items-center">
         <div className="flex items-center w-full mb-[16px]">
           <div className="flex-1 h-px bg-gray-300" />
@@ -130,7 +130,7 @@ export default function LoginPage() {
           >
             <Image
               src="/google-logo.svg"
-              alt="Google login"
+              alt="Google 로그인"
               width={24}
               height={24}
             />
@@ -142,7 +142,7 @@ export default function LoginPage() {
           >
             <Image
               src="/kakao-logo.svg"
-              alt="Kakao login"
+              alt="Kakao 로그인"
               width={24}
               height={24}
             />

--- a/src/app/signup/layout.tsx
+++ b/src/app/signup/layout.tsx
@@ -1,4 +1,3 @@
-// app/signup/layout.tsx
 import type { Metadata } from "next";
 import TopBarWrapper from "@/components/Navigation/TopBarWrapper";
 

--- a/src/app/signup/success/SuccessContent.tsx
+++ b/src/app/signup/success/SuccessContent.tsx
@@ -7,7 +7,7 @@ import Image from "next/image";
 export default function SuccessPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const from = searchParams.get("from"); // 'signup' or 'password'
+  const from = searchParams.get("from"); 
 
   useEffect(() => {
     const timeout = setTimeout(() => {

--- a/src/libs/axiosInstance.ts
+++ b/src/libs/axiosInstance.ts
@@ -1,0 +1,49 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_HOST,
+  withCredentials: true, 
+});
+
+api.interceptors.request.use(
+  (config) => {
+    const accessToken = localStorage.getItem("accessToken");
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const { config, response } = error;
+
+    if (!response || response.status !== 401 || config._retry) {
+      return Promise.reject(error);
+    }
+
+    config._retry = true;
+
+    try {
+      const res = await api.post("/api/auth/reissue");
+      const newAccessToken = res.data.data?.accessToken;
+
+      if (newAccessToken) {
+        localStorage.setItem("accessToken", newAccessToken);
+        config.headers.Authorization = `Bearer ${newAccessToken}`;
+        return api(config);
+      } else {
+        throw new Error("토큰 재발급 실패");
+      }
+    } catch (reissueError) {
+      localStorage.removeItem("accessToken");
+      window.location.href = "/login";
+      return Promise.reject(reissueError);
+    }
+  }
+);
+
+export default api;


### PR DESCRIPTION
## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #25 

## 📎 𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- JWT 기반 로그인 시 액세스 토큰 재발급 로직을 구현했습니다.
- 401 응답 시 /api/auth/reissue API를 호출하여 액세스 토큰을 재발급하고, 요청을 재시도하도록 처리했습니다.
- refreshToken은 httpOnly 쿠키 기반으로 처리하며, 클라이언트 JS에서는 접근하지 않도록 구성했습니다.


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
- https://klloo.github.io/react-login-jwt/ 해당 블로그 글 참고하여 작업했습니다. 보완할 부분 있으면 의견 부탁드립니다!